### PR TITLE
Updated GitHub Action checkout version and removed cache

### DIFF
--- a/.github/workflows/linux-jdks-with-current-maven-ci.yml
+++ b/.github/workflows/linux-jdks-with-current-maven-ci.yml
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-name: JDKBuilds
+name: Compatibility
 
 on:
   push:
@@ -35,13 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     container: "maven:${{ matrix.platform }}"
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/cache@v1
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ matrix.platform }}-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-${{ matrix.platform }}-
+      - uses: actions/checkout@v3
       - name: 'Build'
         run: mvn -B -V clean verify --fail-at-end
 


### PR DESCRIPTION
- Cache had some failures, and with our project size it is not much helpful tool.
- Failures started with #16 , seems caches don't like temporary directories and files, probably removed after the invoker plugin stopped the JVM and temp files were deleted, while cache already started processing them? Not sure.
- see also https://github.com/actions/runner/issues/449