### PR TITLE
Fix dependency resolving in visual studio code

### DIFF
--- a/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
+++ b/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <lifecycleMappingMetadata>
   <pluginExecutions>
     <pluginExecution>

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/DECORATION/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/DECORATION/1.0.0 http://maven.apache.org/xsd/decoration-1.0.0.xsd">
   <body>
     <menu name="Overview">


### PR DESCRIPTION
In visual studio code, we cannot open our project correctly due to the encoding in the maven lifecycle metadata xml file being ISO-8859-1.

We get this error:
Cannot read lifecycle mapping metadata for artifact org.codehaus.mojo:native2ascii-maven-plugin:maven-plugin:2.1.0:runtime Cause: UTF-8 BOM plus xml decl of ISO-8859-1 is incompatible (position: START_DOCUMENT seen <?xml version="1.0" encoding="ISO-8859-1"... @1:42) 